### PR TITLE
Add unit test for parser.py

### DIFF
--- a/src/lbry_batch_uploader/parser.py
+++ b/src/lbry_batch_uploader/parser.py
@@ -1,27 +1,38 @@
+# import sys
 from argparse import ArgumentParser
-from utils import RFC5646_LANGUAGE_TAGS, LICENSES
+from lbry_batch_uploader.utils import RFC5646_LANGUAGE_TAGS, LICENSES
 
 
 class Parser:
     def __init__(self):
-        self.parser = ArgumentParser(
+        self.argparser = ArgumentParser(
             description="Batch uploader for LBRY Desktop"
             )
+        self._add_args()
 
-        self.parser.add_argument(
+    def parse(self, cmd_args):
+        self.args = self.argparser.parse_args(cmd_args)
+
+        if ((self.args.license == "Other") and (self.args.license_url is None)) or \
+                ((self.args.license != "Other") and (self.args.license_url is not None)):
+            err_msg = "--license-url should be specified if and only if --license='Other'"
+            self.argparser.error(err_msg)
+
+    def _add_args(self):
+        self.argparser.add_argument(
             "file_directory",
             type=str,
             help="""The absolute path of directory that \
                     contains the files to be uploaded"""
             )
 
-        self.parser.add_argument(
+        self.argparser.add_argument(
             "channel_name",
             type=str,
             help="The name of publisher channel (with the @)"
             )
 
-        self.parser.add_argument(
+        self.argparser.add_argument(
             "--optimize-file",
             action="store_true",
             help="""Whether to transcode the video & audio or not, \
@@ -31,7 +42,7 @@ class Parser:
                     in the LBRY Desktop."""
             )
 
-        self.parser.add_argument(
+        self.argparser.add_argument(
                 "--port",
                 default=5279,
                 type=int,
@@ -39,7 +50,7 @@ class Parser:
                         default to 5279 if not specified."""
             )
 
-        self.parser.add_argument(
+        self.argparser.add_argument(
             "--bid",
             default=0.0001,
             type=float,
@@ -47,7 +58,7 @@ class Parser:
                     default to 0.0001 if not specified."""
             )
 
-        self.parser.add_argument(
+        self.argparser.add_argument(
             "--fee-amount",
             default=0.,
             type=float,
@@ -55,7 +66,7 @@ class Parser:
                     default to 0 if not specified."""
             )
 
-        self.parser.add_argument(
+        self.argparser.add_argument(
                 "--tags",
                 nargs="+",
                 default=[],
@@ -64,20 +75,20 @@ class Parser:
                         default to [] if not specified."""
             )
 
-        self.parser.add_argument(
+        self.argparser.add_argument(
                 "--languages",
                 nargs="+",
-                default=['en'],
+                default=["en"],
                 type=str,
                 choices=list(RFC5646_LANGUAGE_TAGS.keys()),
                 help="""The languages of the claims in RFC5646 format, \
-                        default to ['en'] if not specified. \
+                        default to ["en"] if not specified. \
                         More than one could be specified. \
                         Please refer to RFC5646 for the complete list.""",
                 metavar="L"
             )
 
-        self.parser.add_argument(
+        self.argparser.add_argument(
                 "--license",
                 type=str,
                 choices=LICENSES,
@@ -86,7 +97,7 @@ class Parser:
                 metavar="LICENSE"
             )
 
-        self.parser.add_argument(
+        self.argparser.add_argument(
                 "--license-url",
                 type=str,
                 help="""The url of custom license. \
@@ -94,12 +105,12 @@ class Parser:
                         if and only if --license='Other'."""
             )
 
-        self.args = self.parser.parse_args()
 
-        if ((self.args.license == "Other") and (self.args.license_url is None)) or \
-                ((self.args.license != "Other") and (self.args.license_url is not None)):
-            err_msg = "--license-url should be specified if and only if --license='Other'"
-            self.parser.error(err_msg)
+# def main():
+#     """Usage"""
+#     parser = Parser()
+#     parser.parse(sys.argv[1:])
+#     args = parser.args
 
 
 if __name__ == "__main__":

--- a/src/lbry_batch_uploader/upload.py
+++ b/src/lbry_batch_uploader/upload.py
@@ -1,7 +1,7 @@
 import os
-from parser import Parser
-from uploader import Uploader
-from utils import get_file_name_no_ext, get_file_name_no_ext_clean
+from lbry_batch_uploader.parser import Parser
+from lbry_batch_uploader.uploader import Uploader
+from lbry_batch_uploader.utils import get_file_name_no_ext, get_file_name_no_ext_clean
 
 
 def main():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,102 @@
+import pytest
+from lbry_batch_uploader.parser import Parser
+
+
+@pytest.fixture
+def parser():
+    return Parser()
+
+
+def assert_namespace(
+    p,
+    file_directory, channel_name,
+    optimize_file, port, bid, fee_amount,
+    tags, languages, license, license_url
+):
+    assert p.args.file_directory == file_directory
+    assert p.args.channel_name == channel_name
+
+    if optimize_file:
+        assert p.args.optimize_file
+    else:
+        assert not p.args.optimize_file
+
+    assert p.args.port == port
+    assert p.args.bid == bid
+    assert p.args.fee_amount == fee_amount
+    assert p.args.tags == tags
+    assert p.args.languages == languages
+
+    if license is None:
+        assert p.args.license is license
+    else:
+        assert p.args.license == license
+
+    if license_url is None:
+        assert p.args.license_url is license_url
+    else:
+        assert p.args.license_url == license_url
+
+
+class TestPositionalArgs:
+    @pytest.mark.parametrize(
+        "args",
+        [("path/to/dir", "test_ch")]
+    )
+    def test_pos_args_all(self, parser, args, capsys):
+        parser.parse(args)
+
+        captured = capsys.readouterr()
+        assert (captured.out == "") and (captured.err == "")
+
+        assert_namespace(
+            parser,
+            "path/to/dir", "test_ch",
+            False, 5279, 0.0001, 0.,
+            [], ["en"], None, None
+        )
+
+    @pytest.mark.parametrize(
+        "args",
+        [
+            (),
+            ("path/to/dir",),
+            ("path/to/dir", "--optimize-file"),
+            ("path/to/dir", "--bid", "0.5")
+        ]
+    )
+    def test_pos_args_missing(self, parser, args, capsys):
+        with pytest.raises(SystemExit):
+            parser.parse(args)
+
+        captured = capsys.readouterr()
+        missing_args = "file_directory, channel_name" \
+                        if not args else "channel_name"
+        err_msg = f"{parser.argparser.prog}: error: " + \
+                    "the following arguments are required: " + \
+                    f"{missing_args}"
+        assert captured.out == ""
+        assert err_msg in captured.err
+
+        err_msg_args = "'Parser' object has no attribute 'args'"
+        with pytest.raises(AttributeError,match=err_msg_args):
+            args = parser.args
+
+
+class TestHelpOption:
+    @pytest.mark.parametrize(
+        "args",
+        ["-h", "--help"]
+    )
+    def test_help(self, parser, args, capsys):
+        with pytest.raises(SystemExit):
+            parser.parse([args])
+
+        captured = capsys.readouterr()
+        help_string_head = f"usage: {parser.argparser.prog} [-h]"
+        assert help_string_head in captured.out
+        assert captured.err == ""
+
+        err_msg_args = "'Parser' object has no attribute 'args'"
+        with pytest.raises(AttributeError,match=err_msg_args):
+            args = parser.args

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -81,4 +81,3 @@ class TestGetFileNameNoExtClean:
 #         # cmd_3 = ["tr", "-d", ","]
 #         # cmd_4 = ["awk", "-F", ":", "{print ($3+$2*60+$1*3600)/2}"]
 #         pass
-


### PR DESCRIPTION
1. The unit tests cover the behaviour of positional args and the help option for  `Parser.argparser`

2. Minor adjustment for the `Parser` class based on test results