### PR TITLE
Add support to Python3.6-3.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ['3.9', '3.10']
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,10 +11,13 @@ license_file = LICENSE
 url = https://github.com/thk-cheng/lbry_batch_uploader
 project_urls =
     Bug Tracker = https://github.com/thk-cheng/lbry_batch_uploader/issues
-platforms = unix, linux, osx
+platforms = cygwin, linux, osx, unix, win32, win64
 classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
 
@@ -23,16 +26,16 @@ package_dir =
     =src
 packages =
     lbry_batch_uploader
-python_requires = >=3.9
+python_requires = >=3.6
 install_requires =
     requests>=2
-zip_sage = no
+zip_safe = no
 
 [options.extras_require]
 testing =
     flake8>=4.0
     mypy>=0.950
-    pytest>=7.1
+    pytest>=7.0
     pytest-cov>=3.0
     tox>=3.25
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,14 @@
 [tox]
 minversion = 3.25.0
-envlist = py39, py310, flake8, mypy
+envlist = py36, py37, py38, py39, py310, flake8, mypy
 isolated_build = true
 
 [gh-actions]
 python =
-    3.9: py39, mypy, flake8
+    3.6: py36, mypy, flake8
+    3.7: py37
+    3.8: py38
+    3.9: py39
     3.10: py310
 
 [testenv]
@@ -17,12 +20,12 @@ commands =
     pytest --basetemp={envtmpdir} --cov-report term-missing
 
 [testenv:flake8]
-basepython = python3.9
+basepython = python3.6
 deps = flake8
 commands = flake8 src
 
 [testenv:mypy]
-basepython = python3.9
+basepython = python3.6
 deps =
     -r{toxinidir}/requirements_dev.txt
 commands = mypy src


### PR DESCRIPTION
1. Relax Python version requirement to 3.6
2. Add automated testing for py3.6-3.8