### PR TITLE
Add support for Python3.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ['3.9', '3.10']
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=42.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
-addopts = "--cov=lbry_batch_uploader"
+addopts = "--cov=lbry_batch_uploader --cov-report term-missing"
 testpaths = [
     "tests",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,10 +11,13 @@ license_file = LICENSE
 url = https://github.com/thk-cheng/lbry_batch_uploader
 project_urls =
     Bug Tracker = https://github.com/thk-cheng/lbry_batch_uploader/issues
-platforms = unix, linux, osx
+platforms = cygwin, linux, osx, unix, win32, win64
 classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
 
@@ -23,16 +26,16 @@ package_dir =
     =src
 packages =
     lbry_batch_uploader
-python_requires = >=3.9
+python_requires = >=3.6
 install_requires =
     requests>=2
-zip_sage = no
+zip_safe = no
 
 [options.extras_require]
 testing =
     flake8>=4.0
     mypy>=0.950
-    pytest>=7.1
+    pytest>=7.0
     pytest-cov>=3.0
     tox>=3.25
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = lbry_batch_uploader
-version = 0.1.0
+version = 0.2.0
 author = thk-cheng
 author_email = kenneth.cheng.tsun.him@gmail.com
 description = A convenient batch uploader for LBRY Desktop written in Python
@@ -15,8 +15,6 @@ platforms = cygwin, linux, osx, unix, win32, win64
 classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -26,7 +24,7 @@ package_dir =
     =src
 packages =
     lbry_batch_uploader
-python_requires = >=3.6
+python_requires = >=3.8
 install_requires =
     requests>=2
 zip_safe = no

--- a/src/lbry_batch_uploader/uploader.py
+++ b/src/lbry_batch_uploader/uploader.py
@@ -2,6 +2,7 @@ import os
 import time
 import requests
 from argparse import Namespace
+from typing import Dict, List
 from .utils import (
     get_file_name_no_ext,
     get_file_name_no_ext_clean,
@@ -23,7 +24,7 @@ class Uploader:
             get_file_name_no_ext(name) for name in files_name_valid
         ]
 
-        self.files_valid: dict[str, dict[str, str]] = {}
+        self.files_valid: Dict[str, Dict[str, str]] = {}
         for fn, fn_no_ext in zip(files_name_valid, files_name_valid_no_ext):
             self.files_valid[fn_no_ext] = {
                 "file_name": fn,
@@ -100,7 +101,7 @@ class Uploader:
                 print("Wait 10 seconds to space out uploads...", end="\n\n")
                 time.sleep(10)
 
-    def _get_valid_files(self, files_name_all) -> list[str]:
+    def _get_valid_files(self, files_name_all) -> List[str]:
         """Get all valid files for upload in the specified directory."""
         target_ext = ("mp4", "mkv", "webm", "mp3", "opus")
         files_name_valid = []

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,11 @@
 [tox]
 minversion = 3.25.0
-envlist = py36, py37, py38, py39, py310, flake8, mypy
+envlist = py38, py39, py310, flake8, mypy
 isolated_build = true
 
 [gh-actions]
 python =
-    3.6: py36, mypy, flake8
-    3.7: py37
-    3.8: py38
+    3.8: py38, mypy, flake8
     3.9: py39
     3.10: py310
 
@@ -20,12 +18,12 @@ commands =
     pytest --basetemp={envtmpdir} --cov-report term-missing
 
 [testenv:flake8]
-basepython = python3.6
+basepython = python3.8
 deps = flake8
 commands = flake8 src
 
 [testenv:mypy]
-basepython = python3.6
+basepython = python3.8
 deps =
     -r{toxinidir}/requirements_dev.txt
 commands = mypy src

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,14 @@
 [tox]
 minversion = 3.25.0
-envlist = py39, py310, flake8, mypy
+envlist = py36, py37, py38, py39, py310, flake8, mypy
 isolated_build = true
 
 [gh-actions]
 python =
-    3.9: py39, mypy, flake8
+    3.6: py36, mypy, flake8
+    3.7: py37
+    3.8: py38
+    3.9: py39
     3.10: py310
 
 [testenv]
@@ -17,12 +20,12 @@ commands =
     pytest --basetemp={envtmpdir} --cov-report term-missing
 
 [testenv:flake8]
-basepython = python3.9
+basepython = python3.6
 deps = flake8
 commands = flake8 src
 
 [testenv:mypy]
-basepython = python3.9
+basepython = python3.6
 deps =
     -r{toxinidir}/requirements_dev.txt
 commands = mypy src


### PR DESCRIPTION
1. Relax the version requirement of Python to 3.8
2. Add automated testing for Python3.8 on different platforms
3. Comply with the typing module of Python3.8 (e.g. use Dict instead of dict)