### PR TITLE
Fix InputValueIsNoneError for the license parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ channel_name               The name of the publisher channel (with the @)
 --languages L [L ...]      The languages of the claims in RFC5646 format, default to ["en"] if not specified.
                            More than one could be specified. Please refer to RFC5646 for the complete list.
 
---license LICENSE          The publication license of the claims. You must choose from the following list.
+--license LICENSE          The publication license of the claims, default to "Public Domain" if not specified.
+                           You must choose from the following list.
                            List of available licenses: {
                                Public Domain,
                                Creative Commons Attribution 4.0 International,
@@ -99,25 +100,25 @@ channel_name               The name of the publisher channel (with the @)
                                Other
                            }
 
---license-url LICENSE_URL  The url of custom license. This option should be specified if and only if --license='Other'.
+--license-url LICENSE_URL  The url of custom license. This option should be specified if and only if --license="Other".
 ```
 
 ### Example
 
 ```shell
 python -m lbry_batch_uploader \
-    "/Users/your_username/path/to/dir" \
-    "@batch-upload-testing" \
+    "/path/to/dir" \
+    "@abc-xyz-ch" \
     --optimize-file \
     --port 9999 \
     --bid 0.1 \
     --fee-amount 1.23 \
-    --tags "Testing" "Python" "LBRY" \
+    --tags "tag1" "tag2" "tag3" \
     --languages "en" \
     --license "Creative Commons Attribution-NonCommercial 4.0 International"
 ```
 
-n.b. If you would like to explore the full list of optional arguments that lbrynet accepts, please head to [here](https://github.com/thk-cheng/lbry_batch_uploader/tree/main/notebooks) and have fun with the notebooks!
+n.b. If you would like to explore the full list of optional arguments that lbrynet accepts, please head to [here](https://github.com/thk-cheng/lbry_batch_uploader/tree/main/notebooks) for the notebooks or [here](https://lbry.tech/api/sdk) for the official lbrynet api documentation. Have fun!
 
 ## Developing
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = lbry_batch_uploader
-version = 1.0.3
+version = 1.1.0
 author = thk-cheng
 author_email = kenneth.cheng.tsun.him@gmail.com
 description = A convenient batch uploader for LBRY Desktop written in Python

--- a/src/lbry_batch_uploader/parser.py
+++ b/src/lbry_batch_uploader/parser.py
@@ -97,6 +97,7 @@ class Parser:
 
         self.argparser.add_argument(
             "--license",
+            default="Public Domain",
             type=str,
             choices=LICENSES,
             help="""The publication license of the claims. \

--- a/src/lbry_batch_uploader/uploader.py
+++ b/src/lbry_batch_uploader/uploader.py
@@ -98,9 +98,13 @@ class Uploader:
             req_info: dict = req_json[info_type]
         except KeyError as e:
             req_err = req_json["error"]
-            if req_err["data"]["name"] == "ValueError":
+            req_err_name = req_err["data"]["name"]
+            if req_err_name == "ValueError":
                 raise ValueError(req_err["message"]) from None
             else:
+                print(
+                    f"Error msg from lbrynet api:\n {req_err_name}: {req_err['message']}\n\n"
+                )
                 raise e from None
 
         return req_info

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -78,7 +78,7 @@ class TestPositionalArgs:
             "0",
             [],
             ["en"],
-            None,
+            "Public Domain",
             None,
         )
 

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -395,6 +395,7 @@ class TestGetReqInfo:
                 {
                     "error": {
                         "data": {"name": "OtherError"},
+                        "message": "This is a test error message.",
                     }
                 },
                 "result",
@@ -403,6 +404,7 @@ class TestGetReqInfo:
                 {
                     "error": {
                         "data": {"name": "OtherError"},
+                        "message": "This is a test error message.",
                     }
                 },
                 "data",
@@ -410,11 +412,21 @@ class TestGetReqInfo:
         ],
     )
     def test_othererrors(
-        self, uploader_normal: Type[Uploader], req_json: dict, info_type: str
+        self,
+        uploader_normal: Type[Uploader],
+        req_json: dict,
+        info_type: str,
+        capsys: Type[pytest.CaptureFixture],
     ) -> None:
         """Test the case when other exception is passed back from lbrynet."""
-        with pytest.raises(KeyError):
+        with pytest.raises(KeyError, match=f"{info_type}"):
             uploader_normal._get_req_info(req_json, info_type)
+
+        captured = capsys.readouterr()
+        out_msg_0 = "Error msg from lbrynet api:"
+        out_msg_1 = "OtherError: This is a test error message."
+        assert out_msg_0 in captured.out
+        assert out_msg_1 in captured.out
 
 
 class TestGetAllFiles:


### PR DESCRIPTION
Fix error observed in #47.

- `license` is now default to `Public Domain` since it is no longer optional.
- The `_get_req_info` method in `uploader.py` is also updated, so that the error message returned by the lbrynet api is exposed to the user as well.
- Bump version to v1.1.0